### PR TITLE
realign translate icon in navbar

### DIFF
--- a/templates/toggleinlinestranslationstate.mustache
+++ b/templates/toggleinlinestranslationstate.mustache
@@ -1,5 +1,5 @@
 <div class="popover-region dropdown translation-icon-wrapper">
-    <a class="nav-link d-inline-block position-relative icon-no-margin" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="#" role="button">
+    <a class="nav-link position-relative icon-no-margin" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="#" role="button">
         <i class="icon icon-translate-default">
         </i>
     </a>


### PR DESCRIPTION
This aligns the translate symbol with the other navbar icons

![misalignedtranslatesymbol](https://github.com/andrewhancox/moodle-filter_translations/assets/5802893/08a61b25-62a5-47ef-9d81-9d2a7591ef22)
