### PR TITLE
Update translator.php to preserve stale manual translations

### DIFF
--- a/classes/translator.php
+++ b/classes/translator.php
@@ -328,7 +328,7 @@ class translator {
             }
         }
 
-        return array_reverse(array_merge(['en'], $dependencies));
+        return array_reverse(array_merge([$CFG->lang], $dependencies));
     }
 
     /**

--- a/classes/translator.php
+++ b/classes/translator.php
@@ -86,9 +86,11 @@ class translator {
         }
 
         // If no translation can be found, or the only translation is either stale or for a lower priority language then
-        // try automated translations.
-        if (empty($translation) || $translation->get('lastgeneratedhash') != $generatedhash ||
-                $translation->get('targetlanguage') != $language) {
+        // try automated translations - unless its a manual translation. To retranslate manual translation automatically - delete it manually first.
+        if (empty($translation) || 
+                ($translation->get('translationsource') != translation::SOURCE_MANUAL && 
+                 ($translation->get('lastgeneratedhash') != $generatedhash || $translation->get('targetlanguage') != $language)) 
+            ) {
             // First try reverse language string look up.
             $languagestrings = new languagestringreverse();
             $languagestringtranslation = $languagestrings->createorupdate_translation($foundhash, $generatedhash, $text,


### PR DESCRIPTION
preserve manual translations to keep e.g. manual translations of dynamic content (e.g. video embed) stable and also e.g. not overwrite the manual work when just a typo is corrected in the source content and thus the hash changed / the translation 'stale'.  To update manual translations with automated translation, manual translation must be deliberately deleted. 

This is my intended behavior, otherwise manual work is constantly lost. If you agree, I suggest adapting.  Otherwise, I suggest adding the option to 'Always preserve manual translations' in the Config settings and adapt accordingly.